### PR TITLE
Created new dockerfile in root of .sln project

### DIFF
--- a/Application/DockerfileUser
+++ b/Application/DockerfileUser
@@ -1,0 +1,23 @@
+#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+WORKDIR /app
+EXPOSE 80
+EXPOSE 443
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY ["Common/Common.csproj", "Common/"]
+COPY ["UserService/UserService.csproj","UserService/"] 
+RUN dotnet restore "UserService/UserService.csproj"
+COPY . .
+WORKDIR "/src/UserService"
+RUN dotnet build "UserService.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "UserService.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "UserService.dll"]

--- a/Application/UserService/azure-pipelines-userservice.yml
+++ b/Application/UserService/azure-pipelines-userservice.yml
@@ -34,7 +34,7 @@ stages:
         containerRegistry: 'AzureRegistry'
         repository: '$(imageRepo)'
         command: 'buildAndPush'
-        Dockerfile: '$(Build.SourcesDirectory)/Application/UserService/Dockerfile'
+        Dockerfile: '$(Build.SourcesDirectory)/Application/DockerfileUser'
         tags: |
           $(tag)
           latest


### PR DESCRIPTION
Created new dockerfile in root of .sln project. When building the docker image, the '/Common' folder could not be referenced, given that the yaml content of the dockerfile in '/UserService/Dockerfile'. Error 'Dockerfile cant reference content or files in parent directories. Solution : We made a new Dockerfile in the root of the project